### PR TITLE
Fix error in stock_capability readme

### DIFF
--- a/stock_capability/README.md
+++ b/stock_capability/README.md
@@ -1,6 +1,6 @@
 # Stock Capability
 
-This is an example of a _portable capability provider_, a WebAssembly module compiled to the `wasm32-wasi` target that assumes the presence of a WASI-compliant host and also utilizes the waSCC actor SDK. Another way of thinking about _portable capability provider_s is that they are _privileged actors_.
+This is an example of a _portable capability provider_, a WebAssembly module compiled to the `wasm32-wasi` target that assumes the presence of a WASI-compliant host and also utilizes the waSCC actor SDK. Another way of thinking about _portable capability providers_ is that they are _privileged actors_.
 
 This actor responds to the `acme:stock!StockRequest` message by replying with a JSON payload indicating the in-stock quantity. The request is a JSON payload with a single field called `sku`, and the response is a JSON payload containing the `sku`, and `quantity`, and a `ships_within` friendly string.
 


### PR DESCRIPTION
This PR fixes a tiny formatting error in the readme for the stock capability example.