### PR TITLE
Implement static capability feature for keyvalue and inmemory streams

### DIFF
--- a/inmemory-streams/Cargo.toml
+++ b/inmemory-streams/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
-name = "test-streams-provider"
-version = "0.2.0"
+name = "wascc-inmemory-streams"
+version = "0.2.1"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# Enable if the provider will be statically compiled into a host
+static_plugin = []
+
 [dependencies]
-wascc-codec = { version = "0.6.0", path = "../../wascc-codec" }
+wascc-codec = "0.6.0"
 log = "0.4.8"
 env_logger = "0.7.1"

--- a/inmemory-streams/src/lib.rs
+++ b/inmemory-streams/src/lib.rs
@@ -29,30 +29,31 @@ struct EventWrapper {
     timestamp: u64,
 }
 
-capability_provider!(TestStreamsProvider, TestStreamsProvider::new);
+#[cfg(not(feature = "static_plugin"))]
+capability_provider!(InmemoryStreamsProvider, InmemoryStreamsProvider::new);
 
 const CAPABILITY_ID: &str = "wascc:eventstreams";
 
-pub struct TestStreamsProvider {
+pub struct InmemoryStreamsProvider {
     dispatcher: RwLock<Box<dyn Dispatcher>>,
     streams: Arc<RwLock<HashMap<String, Vec<EventWrapper>>>>,
 }
 
-impl Default for TestStreamsProvider {
+impl Default for InmemoryStreamsProvider {
     fn default() -> Self {
         match env_logger::try_init() {
             Ok(_) => {}
             Err(_) => {}
         };
 
-        TestStreamsProvider {
+        InmemoryStreamsProvider {
             dispatcher: RwLock::new(Box::new(NullDispatcher::new())),
             streams: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
 
-impl TestStreamsProvider {
+impl InmemoryStreamsProvider {
     pub fn new() -> Self {
         Self::default()
     }
@@ -119,7 +120,7 @@ impl TestStreamsProvider {
     }
 }
 
-impl CapabilityProvider for TestStreamsProvider {
+impl CapabilityProvider for InmemoryStreamsProvider {
     fn capability_id(&self) -> &'static str {
         CAPABILITY_ID
     }
@@ -160,7 +161,7 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let prov = TestStreamsProvider::new();
+        let prov = InmemoryStreamsProvider::new();
         let config = CapabilityConfiguration {
             module: "testing-actor".to_string(),
             values: gen_config(),

--- a/keyvalue-provider/Cargo.toml
+++ b/keyvalue-provider/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
-name = "keyvalue"
-version = "0.2.0"
+name = "wascc-keyvalue"
+version = "0.2.1"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# Enable if the provider will be statically compiled into a host
+static_plugin = []
+
 [dependencies]
-wascc-codec = { version = "0.6.0",  path = "../../wascc-codec" }
+wascc-codec = "0.6.0"
 log = "0.4.8"
 env_logger = "0.7.1"

--- a/keyvalue-provider/src/lib.rs
+++ b/keyvalue-provider/src/lib.rs
@@ -29,7 +29,7 @@ pub struct KeyvalueProvider {
 
 impl Default for KeyvalueProvider {
     fn default() -> Self {
-        env_logger::init();
+        env_logger::try_init();
 
         KeyvalueProvider {
             dispatcher: RwLock::new(Box::new(NullDispatcher::new())),

--- a/keyvalue-provider/src/lib.rs
+++ b/keyvalue-provider/src/lib.rs
@@ -17,6 +17,7 @@ use wascc_codec::{deserialize, serialize};
 use std::error::Error;
 use std::sync::RwLock;
 
+#[cfg(not(feature = "static_plugin"))]
 capability_provider!(KeyvalueProvider, KeyvalueProvider::new);
 
 const CAPABILITY_ID: &str = "wascc:keyvalue";

--- a/keyvalue-provider/src/lib.rs
+++ b/keyvalue-provider/src/lib.rs
@@ -29,8 +29,10 @@ pub struct KeyvalueProvider {
 
 impl Default for KeyvalueProvider {
     fn default() -> Self {
-        env_logger::try_init();
-
+        match env_logger::try_init() {
+            Ok(_) => {}
+            Err(_) => {}
+        };
         KeyvalueProvider {
             dispatcher: RwLock::new(Box::new(NullDispatcher::new())),
             store: RwLock::new(KeyValueStore::new()),


### PR DESCRIPTION
Updated names of crates as well to bring to parity with other capability providers, and bumped versions to `0.2.1`. If this doesn't fit the versioning standard, I can change that.